### PR TITLE
Track cpu_utilization and show average in interval report

### DIFF
--- a/src/db_driver.h
+++ b/src/db_driver.h
@@ -200,6 +200,7 @@ typedef struct db_result
   struct db_stmt *statement;    /* Pointer to prepared statement (if used) */
   void           *ptr;          /* Pointer to driver-specific data */
   db_row_t       row;           /* Last fetched row */
+  uint64_t       cpu_util;      /* Integer - Percentage 0.5 -> 50 */
 } db_result_t;
 
 typedef enum {

--- a/src/sb_counter.h
+++ b/src/sb_counter.h
@@ -41,6 +41,7 @@ typedef enum {
   SB_CNT_RECONNECT,     /* reconnects */
   SB_CNT_BYTES_READ,    /* bytes read */
   SB_CNT_BYTES_WRITTEN, /* bytes written */
+  SB_CNT_CPU_UTIL_SUM,  /* cpu_util sum */
   SB_CNT_MAX
 } sb_counter_type_t;
 

--- a/src/sysbench.c
+++ b/src/sysbench.c
@@ -213,6 +213,7 @@ static void report_get_common_stat(sb_stat_t *stat, sb_counters_t cnt)
   stat->reconnects =    cnt[SB_CNT_RECONNECT];
   stat->bytes_read =    cnt[SB_CNT_BYTES_READ];
   stat->bytes_written = cnt[SB_CNT_BYTES_WRITTEN];
+  stat->cpu_util_sum  = cnt[SB_CNT_CPU_UTIL_SUM];
 
   stat->time_total = NS2SEC(sb_timer_value(&sb_exec_timer)) -
     sb_globals.warmup_time;

--- a/src/sysbench.h
+++ b/src/sysbench.h
@@ -110,6 +110,8 @@ typedef struct {
 
   uint64_t queue_length;        /* Event queue length (tx_rate-only) */
   uint64_t concurrency;         /* Number of in-flight events (tx_rate-only) */
+
+  double   cpu_util_sum;        /* Sum of cpu utilization */
 } sb_stat_t;
 
 /* Commands */


### PR DESCRIPTION
In this PR, we extract cpu_utilization returned by proctor and keep track of it.
That way, when interval report is generated, it shows the (cpu_utilization sum / total queries).

<img width="566" alt="Screen Shot 2020-08-17 at 5 10 44 PM" src="https://user-images.githubusercontent.com/51671/90444881-b0987680-e0ac-11ea-9f83-881276242567.png">
